### PR TITLE
Add intersection leg snapping support to avoid "sliver" polygons

### DIFF
--- a/polygonizer_dockwidget.py
+++ b/polygonizer_dockwidget.py
@@ -241,7 +241,7 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                     # FIXME we need some snapping flexibility, because this can leave slivers
                     if road.geometry().length() < LEG_LENGTH * 2:
                         LEG_LENGTH = road.geometry().length() / 2
-                    elif road.geometry().length() - LEG_LENGTH * 2 < MAX_SNAP_LENGTH:
+                    elif (road.geometry().length() - (LEG_LENGTH * 2)) < MAX_SNAP_LENGTH:
                         LEG_LENGTH = road.geometry().length() / 2
 
                     # we don't know the start-to-stop orientation of the line, so let's grab some endpoints and look for intersections

--- a/polygonizer_dockwidget.py
+++ b/polygonizer_dockwidget.py
@@ -199,9 +199,9 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         interconnect_polygons_provider = interconnect_polygons_layer.dataProvider()
 
         # ingest parameters of the polygonization algorithm
-        GOAL_SEGMENT_LENGTH = self.goalSegmentLength.value()
-        GOAL_LEG_LENGTH = self.goalLegLength.value()
-        BUFFER_LENGTH = self.polygonWidth.value()
+        GOAL_SEGMENT_LENGTH = self.idealSegmentLengthSpinbox.value()
+        GOAL_LEG_LENGTH = self.idealLegLengthSpinbox.value()
+        BUFFER_LENGTH = self.polygonWidthSpinbox.value()
         BUFFER_DETAIL = 20
 
         end_cap_style = Qgis.EndCapStyle(2)  # flat

--- a/polygonizer_dockwidget.py
+++ b/polygonizer_dockwidget.py
@@ -202,6 +202,7 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         GOAL_SEGMENT_LENGTH = self.idealSegmentLengthSpinbox.value()
         GOAL_LEG_LENGTH = self.idealLegLengthSpinbox.value()
         BUFFER_LENGTH = self.polygonWidthSpinbox.value()
+        MAX_SNAP_LENGTH = self.maxSnapLengthSpinbox.value()
         BUFFER_DETAIL = 20
 
         end_cap_style = Qgis.EndCapStyle(2)  # flat
@@ -239,6 +240,8 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                     # we have a road that is a leg, let's compute the length of the leg
                     # FIXME we need some snapping flexibility, because this can leave slivers
                     if road.geometry().length() < LEG_LENGTH * 2:
+                        LEG_LENGTH = road.geometry().length() / 2
+                    elif road.geometry().length() - LEG_LENGTH * 2 < MAX_SNAP_LENGTH:
                         LEG_LENGTH = road.geometry().length() / 2
 
                     # we don't know the start-to-stop orientation of the line, so let's grab some endpoints and look for intersections

--- a/polygonizer_dockwidget_base.ui
+++ b/polygonizer_dockwidget_base.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>855</width>
-    <height>215</height>
+    <width>861</width>
+    <height>244</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,6 +15,13 @@
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QGridLayout" name="gridLayout">
+    <item row="1" column="0">
+     <widget class="QPushButton" name="doPolygonizerButton">
+      <property name="text">
+       <string>Polygonize Selection</string>
+      </property>
+     </widget>
+    </item>
     <item row="0" column="0">
      <layout class="QFormLayout" name="formLayout">
       <property name="fieldGrowthPolicy">
@@ -140,14 +147,41 @@
         </item>
        </layout>
       </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="maxSnapDistanceLabel">
+        <property name="text">
+         <string>Maximum Snap Distance</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <layout class="QHBoxLayout" name="maxSnapDistanceHorizontalLayout">
+        <item>
+         <widget class="QSpinBox" name="maxSnapDistanceSpinbox">
+          <property name="maximum">
+           <number>150</number>
+          </property>
+          <property name="value">
+           <number>30</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSlider" name="maxSnapDistanceSlider">
+          <property name="maximum">
+           <number>150</number>
+          </property>
+          <property name="value">
+           <number>30</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
-    </item>
-    <item row="1" column="0">
-     <widget class="QPushButton" name="doPolygonizerButton">
-      <property name="text">
-       <string>Polygonize Selection</string>
-      </property>
-     </widget>
     </item>
    </layout>
   </widget>

--- a/polygonizer_dockwidget_base.ui
+++ b/polygonizer_dockwidget_base.ui
@@ -44,10 +44,29 @@
       <item row="0" column="1">
        <layout class="QHBoxLayout" name="idealLegLengthHorizontalLayout">
         <item>
-         <widget class="QSpinBox" name="idealLegLengthSpinbox"/>
+         <widget class="QSpinBox" name="idealLegLengthSpinbox">
+          <property name="minimum">
+           <number>25</number>
+          </property>
+          <property name="maximum">
+           <number>300</number>
+          </property>
+          <property name="value">
+           <number>50</number>
+          </property>
+         </widget>
         </item>
         <item>
          <widget class="QSlider" name="idealLegLengthSlider">
+          <property name="minimum">
+           <number>25</number>
+          </property>
+          <property name="maximum">
+           <number>300</number>
+          </property>
+          <property name="value">
+           <number>50</number>
+          </property>
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -58,10 +77,29 @@
       <item row="1" column="1">
        <layout class="QHBoxLayout" name="idealSegmentLengthHorizontalLayout">
         <item>
-         <widget class="QSpinBox" name="idealSegmentLengthSpinbox"/>
+         <widget class="QSpinBox" name="idealSegmentLengthSpinbox">
+          <property name="minimum">
+           <number>50</number>
+          </property>
+          <property name="maximum">
+           <number>250</number>
+          </property>
+          <property name="value">
+           <number>150</number>
+          </property>
+         </widget>
         </item>
         <item>
          <widget class="QSlider" name="idealSegmentLengthSlider">
+          <property name="minimum">
+           <number>50</number>
+          </property>
+          <property name="maximum">
+           <number>250</number>
+          </property>
+          <property name="value">
+           <number>150</number>
+          </property>
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -72,10 +110,29 @@
       <item row="2" column="1">
        <layout class="QHBoxLayout" name="polygonWidthHorizontalLayout">
         <item>
-         <widget class="QSpinBox" name="polygonWidthSpinbox"/>
+         <widget class="QSpinBox" name="polygonWidthSpinbox">
+          <property name="minimum">
+           <number>10</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>40</number>
+          </property>
+         </widget>
         </item>
         <item>
          <widget class="QSlider" name="polygonWidthSlider">
+          <property name="minimum">
+           <number>10</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>40</number>
+          </property>
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -96,5 +153,102 @@
   </widget>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>idealSegmentLengthSlider</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>idealSegmentLengthSpinbox</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>520</x>
+     <y>80</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>172</x>
+     <y>80</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>idealLegLengthSlider</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>idealLegLengthSpinbox</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>520</x>
+     <y>46</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>172</x>
+     <y>46</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>idealSegmentLengthSpinbox</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>idealSegmentLengthSlider</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>172</x>
+     <y>80</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>520</x>
+     <y>80</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>idealLegLengthSpinbox</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>idealLegLengthSlider</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>172</x>
+     <y>46</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>520</x>
+     <y>46</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>polygonWidthSlider</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>polygonWidthSpinbox</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>520</x>
+     <y>114</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>172</x>
+     <y>114</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>polygonWidthSpinbox</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>polygonWidthSlider</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>172</x>
+     <y>114</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>520</x>
+     <y>114</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/polygonizer_dockwidget_base.ui
+++ b/polygonizer_dockwidget_base.ui
@@ -157,7 +157,7 @@
       <item row="3" column="1">
        <layout class="QHBoxLayout" name="maxSnapDistanceHorizontalLayout">
         <item>
-         <widget class="QSpinBox" name="maxSnapDistanceSpinbox">
+         <widget class="QSpinBox" name="maxSnapLengthSpinbox">
           <property name="maximum">
            <number>150</number>
           </property>
@@ -167,7 +167,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QSlider" name="maxSnapDistanceSlider">
+         <widget class="QSlider" name="maxSnapLengthSlider">
           <property name="maximum">
            <number>150</number>
           </property>
@@ -281,6 +281,38 @@
     <hint type="destinationlabel">
      <x>520</x>
      <y>114</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>maxSnapLengthSlider</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>maxSnapLengthSpinbox</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>535</x>
+     <y>148</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>192</x>
+     <y>148</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>maxSnapLengthSpinbox</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>maxSnapLengthSlider</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>192</x>
+     <y>148</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>535</x>
+     <y>148</y>
     </hint>
    </hints>
   </connection>

--- a/polygonizer_dockwidget_base.ui
+++ b/polygonizer_dockwidget_base.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>448</width>
-    <height>480</height>
+    <width>855</width>
+    <height>215</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,76 +15,82 @@
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QGridLayout" name="gridLayout">
+    <item row="0" column="0">
+     <layout class="QFormLayout" name="formLayout">
+      <property name="fieldGrowthPolicy">
+       <enum>QFormLayout::ExpandingFieldsGrow</enum>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="idealLegLengthLabel">
+        <property name="text">
+         <string>Ideal Leg Lenth</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="idealSegmentLengthLabel">
+        <property name="text">
+         <string>Ideal Segment Length</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="polygonWidthLabel">
+        <property name="text">
+         <string>Polygon Width</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <layout class="QHBoxLayout" name="idealLegLengthHorizontalLayout">
+        <item>
+         <widget class="QSpinBox" name="idealLegLengthSpinbox"/>
+        </item>
+        <item>
+         <widget class="QSlider" name="idealLegLengthSlider">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="1">
+       <layout class="QHBoxLayout" name="idealSegmentLengthHorizontalLayout">
+        <item>
+         <widget class="QSpinBox" name="idealSegmentLengthSpinbox"/>
+        </item>
+        <item>
+         <widget class="QSlider" name="idealSegmentLengthSlider">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="1">
+       <layout class="QHBoxLayout" name="polygonWidthHorizontalLayout">
+        <item>
+         <widget class="QSpinBox" name="polygonWidthSpinbox"/>
+        </item>
+        <item>
+         <widget class="QSlider" name="polygonWidthSlider">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </item>
     <item row="1" column="0">
      <widget class="QPushButton" name="doPolygonizerButton">
       <property name="text">
        <string>Polygonize Selection</string>
       </property>
      </widget>
-    </item>
-    <item row="0" column="0">
-     <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Ideal Leg Lenth</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QSlider" name="goalLegLength">
-        <property name="maximum">
-         <number>300</number>
-        </property>
-        <property name="value">
-         <number>99</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Ideal Segment Length</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSlider" name="goalSegmentLength">
-        <property name="maximum">
-         <number>200</number>
-        </property>
-        <property name="value">
-         <number>100</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Polygon Width</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QSlider" name="polygonWidth">
-        <property name="value">
-         <number>30</number>
-        </property>
-        <property name="tracking">
-         <bool>true</bool>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-     </layout>
     </item>
    </layout>
   </widget>

--- a/polygonizer_dockwidget_base.ui
+++ b/polygonizer_dockwidget_base.ui
@@ -52,7 +52,7 @@
            <number>300</number>
           </property>
           <property name="value">
-           <number>50</number>
+           <number>100</number>
           </property>
          </widget>
         </item>
@@ -65,7 +65,7 @@
            <number>300</number>
           </property>
           <property name="value">
-           <number>50</number>
+           <number>100</number>
           </property>
           <property name="orientation">
            <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
# Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/13624

# PR Contents

* Revisions to the QT UI Layout, including the addition of spin boxes. This was a feature that was on the original list of TODO items, but was not deemed needed for this round of work, but I ended up needing it to allow me to put in precise parameters for the algorithm.
* Automatic leg snapping when the distance that would otherwise be assigned to a "sliver" polygon are below the specified threshold.

# Review

* I'm not sure what process we should put these through for review, so I'm going to invite the normal folks so everyone has awareness on what is going on and follow any direction y'all have. I can do the review via demo if you all think that'd be easiest. This one would take all of 60 seconds.